### PR TITLE
Update Ruby version as Heroku seems to want

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.2.3"
+ruby "2.5.8"
 
 gem "lita"
 gem 'lita-slack', '1.5.0' # slack adapter


### PR DESCRIPTION
Meh, doesn't seem to actually be bringing @sellerbot back online right now, does remove the Heroku warning about cedar-14 end of life.